### PR TITLE
ci: use older runner

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     name: Tests (Elixir ${{matrix.elixir}} | Erlang/OTP ${{matrix.otp}})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -32,6 +32,7 @@ jobs:
           elixir-version: ${{matrix.elixir}}
 
       - uses: actions/cache@v3
+        id: cache
         with:
           path: |
             deps
@@ -41,6 +42,7 @@ jobs:
             ${{ runner.os }}-mix-${{ matrix.otp }}-${{ matrix.elixir }}-
 
       - name: Install Dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
         run: mix deps.get --only test
 
       - name: Run tests
@@ -56,6 +58,7 @@ jobs:
           otp-version: 25.x
           elixir-version: 1.14.x
       - uses: actions/cache@v3
+        id: cache
         with:
           path: |
             deps
@@ -65,6 +68,7 @@ jobs:
             ${{ runner.os }}-mix-25-1.14-
 
       - name: Install Dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
         run: mix deps.get
 
       - name: Run Formatter

--- a/test/credo_language_server_test.exs
+++ b/test/credo_language_server_test.exs
@@ -28,18 +28,22 @@ defmodule CredoLanguageServerTest do
   end
 
   test "can initialize the server" do
-    assert_result(1, %{
-      "capabilities" => %{
-        "textDocumentSync" => %{
-          "openClose" => true,
-          "save" => %{
-            "includeText" => true
-          },
-          "change" => 1
-        }
+    assert_result(
+      1,
+      %{
+        "capabilities" => %{
+          "textDocumentSync" => %{
+            "openClose" => true,
+            "save" => %{
+              "includeText" => true
+            },
+            "change" => 1
+          }
+        },
+        "serverInfo" => %{"name" => "Credo"}
       },
-      "serverInfo" => %{"name" => "Credo"}
-    })
+      500
+    )
   end
 
   test "publishes diagnostics once the client has initialized", %{client: client, cwd: cwd} do

--- a/test/credo_language_server_test.exs
+++ b/test/credo_language_server_test.exs
@@ -49,10 +49,14 @@ defmodule CredoLanguageServerTest do
   test "publishes diagnostics once the client has initialized", %{client: client, cwd: cwd} do
     assert :ok == notify(client, %{method: "initialized", jsonrpc: "2.0", params: %{}})
 
-    assert_notification("window/logMessage", %{
-      "message" => "[Credo] LSP Initialized!",
-      "type" => 4
-    })
+    assert_notification(
+      "window/logMessage",
+      %{
+        "message" => "[Credo] LSP Initialized!",
+        "type" => 4
+      },
+      500
+    )
 
     for file <- ["foo.ex", "bar.ex"] do
       uri =
@@ -119,7 +123,8 @@ defmodule CredoLanguageServerTest do
           },
           "title" => "Disable Credo.Check.Readability.ModuleDoc"
         }
-      ]
+      ],
+      500
     )
   end
 end


### PR DESCRIPTION
OTP 23 and older is not available on more recent Ubuntu versions
