### PR TITLE
chore: fix typo, langauge -> language

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Hex.pm](https://img.shields.io/hexpm/v/credo_language_server)](https://hex.pm/packages/credo_language_server)
 
-credo-langauge-server is an LSP implementation for Credo.
+credo-language-server is an LSP implementation for Credo.
 
 ## Features
 


### PR DESCRIPTION
Found via `typos --format brief`