### PR TITLE
CI update checkout action version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Formatter (1.14.x.x/25.x)
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: erlef/setup-beam@v1
         with:
           otp-version: 25.x

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ credo_language_server-*.tar
 
 /tmp/
 
+.DS_Store


### PR DESCRIPTION
`actions/checkout@v2` gives a warning about node version 12 being deprecated. This change makes the `lint` job use the same version as the `test` job and eliminates that warning.