### PR TITLE
Fix elixir invalid command for bin/credo-language-server

### DIFF
--- a/bin/credo-language-server
+++ b/bin/credo-language-server
@@ -1,4 +1,4 @@
-#!/usr/bin/env elixir --sname undefined
+#!/usr/bin/env -S elixir --sname undefined
 
 System.no_halt(true)
 


### PR DESCRIPTION
I the following error when running /bin/credo-language-server on Linux. This fixes it.

```bash
/usr/bin/env: ‘elixir --sname undefined’: No such file or directory
/usr/bin/env: use -[v]S to pass options in shebang lines
```

Apparently this is from coreutils 8.30 onwards, and I recall that Apple ships ancient versions of these tools, so not sure about compatibility. 